### PR TITLE
#229 run coveralls on CI only in master and dev branches

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,6 +38,6 @@ npm install -g truffle@4.1.12
 # test
 npm run test
 
-# coverage via coveralls.io
-npm run coveralls
+# coverage via coveralls.io, run only for master and dev branches
+if [ "$CI_BRANCH" == "master" ] || [ "$CI_BRANCH" == "dev" ]; then npm run coveralls; fi
 ```


### PR DESCRIPTION
поправил codeship build script
`npm run coveralls`
=>
`if [ "$CI_BRANCH" == "master" ] || [ "$CI_BRANCH" == "dev" ]; then npm run coveralls; fi`